### PR TITLE
Disable text wrap

### DIFF
--- a/inst/docker-scripts/Rmd2md.sh
+++ b/inst/docker-scripts/Rmd2md.sh
@@ -38,6 +38,7 @@ quarto \
     render ${basename2render} \
     --to markdown \
     --output index.md \
+    --wrap=none \
     --metadata "prefer-html:true" \
     --metadata "method:true" \
     --metadata "citation: true" \

--- a/inst/docker-scripts/docx2md.sh
+++ b/inst/docker-scripts/docx2md.sh
@@ -49,6 +49,7 @@ fi
 ${PANDOC} \
     --from docx+styles \
     --to markdown \
+    --wrap=none \
     --standalone \
     --extract-media=./ \
     ${cover_metadata:+"--metadata" "$cover_metadata"} \

--- a/inst/docker-scripts/ipynb2md.sh
+++ b/inst/docker-scripts/ipynb2md.sh
@@ -32,6 +32,7 @@ quarto \
     --execute \
     --to markdown \
     --output index.md \
+    --wrap=none \
     --metadata "prefer-html:true" \
     --metadata "method:true" \
     --metadata "citation: true" \

--- a/inst/docker-scripts/md2md.sh
+++ b/inst/docker-scripts/md2md.sh
@@ -61,6 +61,7 @@ quarto \
     render ${basename2render} \
     --to markdown \
     --output index.md-tmp \
+    --wrap=none \
     ${shift_heading_level:+"--shift-heading-level-by" "$shift_heading_level"} \
     ${fallback_author:+"--metadata" "$fallback_author"} \
     ${cover_metadata:+"--metadata" "$cover_metadata"} \

--- a/inst/docker-scripts/qmd2md.sh
+++ b/inst/docker-scripts/qmd2md.sh
@@ -32,6 +32,7 @@ quarto \
     --execute \
     --to markdown \
     --output index.md \
+    --wrap=none \
     --metadata "prefer-html:true" \
     --metadata "method:true" \
     --metadata "citation: true" \


### PR DESCRIPTION
Text wrap is problematic when doing DOCX to Markdown because words might be split into two.

This was reported to Pandoc in https://github.com/jgm/pandoc/issues/9001.